### PR TITLE
make the RPC2 endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ from osaapi import OSA, PBA
 pem = OSA('mn.hostname.com', port=8888)
 ```
 
+### Custom endpoint
+
+``` {.sourceCode .python}
+from osaapi import OSA, PBA
+
+# connect to OSA
+
+pem = OSA('mn.hostname.com', endpoint=my/custom/endpoint)
+```
+
 Odin Service Automation (OSA) API
 -----------------------------------------
 

--- a/osaapi/__init__.py
+++ b/osaapi/__init__.py
@@ -21,13 +21,13 @@ class OpenApiError(Exception):
 
 
 class PBA(object):
-    def __init__(self, host, user=None, password=None, ssl=False, verbose=False, port=5224):
+    def __init__(self, host, user=None, password=None, ssl=False, verbose=False, port=5224, endpoint="RPC2"):
         protocol = 'https' if ssl else 'http'
         if user:
             self.__server__ = client.ServerProxy(
-                "%s://%s:%s@%s:%s/RPC2" % (protocol, user, password, host, str(port)))
+                "%s://%s:%s@%s:%s/%s" % (protocol, user, password, host, str(port), endpoint))
         else:
-            self.__server__ = client.ServerProxy("%s://%s:%s/RPC2" % (protocol, host, str(port)))
+            self.__server__ = client.ServerProxy("%s://%s:%s/%s" % (protocol, host, str(port), endpoint))
         self.__server__._ServerProxy__verbose = verbose
         self.host = host
 
@@ -59,13 +59,13 @@ class PBA(object):
 
 
 class OSA(object):
-    def __init__(self, host, user=None, password=None, ssl=False, verbose=False, port=8440):
+    def __init__(self, host, user=None, password=None, ssl=False, verbose=False, port=8440, endpoint="RPC2"):
         protocol = 'https' if ssl else 'http'
         if user:
             self.__server__ = client.ServerProxy(
-                "%s://%s:%s@%s:%s/RPC2" % (protocol, user, password, host, str(port)))
+                "%s://%s:%s@%s:%s/%s" % (protocol, user, password, host, str(port), str(endpoint)))
         else:
-            self.__server__ = client.ServerProxy("%s://%s:%s/RPC2" % (protocol, host, str(port)))
+            self.__server__ = client.ServerProxy("%s://%s:%s/%s" % (protocol, host, str(port), str(endpoint)))
         self.__server__._ServerProxy__verbose = verbose
 
     # PPA only


### PR DESCRIPTION
I ran into a situation where the Odin endpoint isn't RPC2. This patch makes it configurable.